### PR TITLE
Add responsive block breaker game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ブロック崩し</title>
+    <link rel="stylesheet" href="src/style.css" />
+  </head>
+  <body>
+    <main class="game-wrapper">
+      <header class="game-header">
+        <h1>ブロック崩し</h1>
+        <div class="scoreboard" aria-live="polite">
+          <div class="scoreboard__item">
+            <span class="scoreboard__label">スコア</span>
+            <span id="score" class="scoreboard__value">0</span>
+          </div>
+          <div class="scoreboard__item">
+            <span class="scoreboard__label">ハイスコア</span>
+            <span id="highScore" class="scoreboard__value">0</span>
+          </div>
+          <div class="scoreboard__item">
+            <span class="scoreboard__label">レベル</span>
+            <span id="level" class="scoreboard__value">1</span>
+          </div>
+          <div class="scoreboard__item">
+            <span class="scoreboard__label">残りライフ</span>
+            <span id="lives" class="scoreboard__value">3</span>
+          </div>
+        </div>
+      </header>
+      <section class="game-area">
+        <canvas id="gameCanvas" width="480" height="640" aria-label="ブロック崩しゲーム" role="img"></canvas>
+        <div class="controls">
+          <button id="startButton" type="button">スタート</button>
+        </div>
+      </section>
+      <section class="instructions">
+        <h2>遊び方</h2>
+        <p>
+          パドルを左右に動かし、ボールを跳ね返してブロックをすべて壊しましょう。レベルが進むほどブロック数とボールのスピードが上がります。
+        </p>
+        <ul>
+          <li>PC: マウスまたは左右キーでパドルを動かします。</li>
+          <li>スマホ / タブレット: 画面をタッチしてスライドするとパドルが動きます。</li>
+          <li>スタート / リスタートボタン、またはスペースキーでゲームを開始・再開できます。</li>
+          <li>プレイ中にスペースキーを押すと一時停止 / 再開します。</li>
+        </ul>
+      </section>
+    </main>
+    <script src="src/app.js" type="module"></script>
+  </body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,577 @@
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+const startButton = document.getElementById('startButton');
+const scoreLabel = document.getElementById('score');
+const highScoreLabel = document.getElementById('highScore');
+const levelLabel = document.getElementById('level');
+const livesLabel = document.getElementById('lives');
+
+const BASE_WIDTH = 480;
+const BASE_HEIGHT = 640;
+const BRICK_COLUMNS = 8;
+const BRICK_MARGIN = 8;
+const BRICK_HEIGHT = 22;
+const INITIAL_LIVES = 3;
+const STORAGE_KEY = 'blockBreakerHighScore';
+
+const paddle = {
+  width: BASE_WIDTH * 0.22,
+  height: 14,
+  x: (BASE_WIDTH - BASE_WIDTH * 0.22) / 2,
+  y: BASE_HEIGHT - 60,
+  speed: 8,
+};
+
+const ball = {
+  radius: 8,
+  x: BASE_WIDTH / 2,
+  y: BASE_HEIGHT - 80,
+  dx: 0,
+  dy: 0,
+  speed: 5,
+};
+
+const input = {
+  left: false,
+  right: false,
+};
+
+let bricks = [];
+
+const gameState = {
+  status: 'idle',
+  score: 0,
+  level: 1,
+  lives: INITIAL_LIVES,
+  highScore: loadHighScore(),
+  message: 'スタートボタンでゲーム開始！',
+  animationId: null,
+};
+
+function loadHighScore() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? Number(stored) : 0;
+  } catch (error) {
+    return 0;
+  }
+}
+
+function saveHighScore(value) {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(value));
+  } catch (error) {
+    // Ignore persistence errors (e.g. Safari private mode)
+  }
+}
+
+function setupCanvas() {
+  const pixelRatio = window.devicePixelRatio || 1;
+  canvas.width = BASE_WIDTH * pixelRatio;
+  canvas.height = BASE_HEIGHT * pixelRatio;
+  ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+}
+
+function roundedRectPath(x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function setStatus(newStatus, message = null) {
+  gameState.status = newStatus;
+  if (typeof message === 'string') {
+    gameState.message = message;
+  }
+  updateStartButtonLabel();
+}
+
+function updateStartButtonLabel() {
+  let label = 'スタート';
+  if (gameState.status === 'running') {
+    label = '一時停止';
+  } else if (gameState.status === 'paused') {
+    label = '再開';
+  } else if (gameState.status === 'gameOver') {
+    label = 'リスタート';
+  }
+  startButton.textContent = label;
+}
+
+function updateHud() {
+  scoreLabel.textContent = gameState.score;
+  highScoreLabel.textContent = gameState.highScore;
+  levelLabel.textContent = gameState.level;
+  livesLabel.textContent = gameState.lives;
+}
+
+function updateScore(diff) {
+  gameState.score = Math.max(gameState.score + diff, 0);
+  if (gameState.score > gameState.highScore) {
+    gameState.highScore = gameState.score;
+    saveHighScore(gameState.highScore);
+  }
+  updateHud();
+}
+
+function resetPaddle() {
+  const maxWidth = BASE_WIDTH * 0.26;
+  const minWidth = BASE_WIDTH * 0.16;
+  const widthReduction = (gameState.level - 1) * 12;
+  paddle.width = clamp(maxWidth - widthReduction, minWidth, maxWidth);
+  paddle.x = (BASE_WIDTH - paddle.width) / 2;
+  paddle.y = BASE_HEIGHT - 60;
+  paddle.speed = 8 + Math.min(gameState.level - 1, 6);
+}
+
+function placeBallAbovePaddle() {
+  ball.x = paddle.x + paddle.width / 2;
+  ball.y = paddle.y - ball.radius - 4;
+  ball.dx = 0;
+  ball.dy = 0;
+}
+
+function setBallSpeedForLevel() {
+  ball.speed = 4.5 + (gameState.level - 1) * 0.6;
+  ball.speed = Math.min(ball.speed, 9);
+}
+
+function buildBricksForLevel(level) {
+  bricks = [];
+  const baseRows = 4;
+  const maxAdditionalRows = 5;
+  const rows = Math.min(baseRows + level - 1, baseRows + maxAdditionalRows);
+  const durability = Math.min(1 + Math.floor((level - 1) / 2), 3);
+  const totalMarginX = BRICK_MARGIN * (BRICK_COLUMNS + 1);
+  const brickWidth = (BASE_WIDTH - totalMarginX) / BRICK_COLUMNS;
+  const offsetTop = 70;
+
+  for (let row = 0; row < rows; row += 1) {
+    for (let col = 0; col < BRICK_COLUMNS; col += 1) {
+      const strength = clamp(durability - Math.floor(row / 3), 1, 3);
+      bricks.push({
+        x: BRICK_MARGIN + col * (brickWidth + BRICK_MARGIN),
+        y: offsetTop + row * (BRICK_HEIGHT + BRICK_MARGIN),
+        width: brickWidth,
+        height: BRICK_HEIGHT,
+        status: strength,
+        hue: 200 + row * 14 + level * 4,
+      });
+    }
+  }
+}
+
+function prepareLevel({ announce = true, message } = {}) {
+  resetPaddle();
+  setBallSpeedForLevel();
+  buildBricksForLevel(gameState.level);
+  placeBallAbovePaddle();
+  if (announce) {
+    setStatus(
+      'ready',
+      message ?? `レベル${gameState.level} スタート準備完了！スペースキーまたはボタンで開始`,
+    );
+  }
+}
+
+function launchBall() {
+  if (gameState.status !== 'ready' && gameState.status !== 'idle') {
+    return;
+  }
+
+  setBallSpeedForLevel();
+  const minAngle = Math.PI / 6;
+  const maxAngle = (5 * Math.PI) / 12;
+  const angle = minAngle + Math.random() * (maxAngle - minAngle);
+  const horizontalDirection = Math.random() < 0.5 ? -1 : 1;
+  ball.dx = Math.cos(angle) * ball.speed * horizontalDirection;
+  ball.dy = -Math.sin(angle) * ball.speed;
+  setStatus('running', '');
+}
+
+function resumeGame() {
+  if (gameState.status === 'paused') {
+    setStatus('running', '');
+  }
+}
+
+function pauseGame() {
+  if (gameState.status === 'running') {
+    setStatus('paused', '一時停止中… スペースキーまたはボタンで再開');
+  }
+}
+
+function startNewGame() {
+  gameState.score = 0;
+  gameState.level = 1;
+  gameState.lives = INITIAL_LIVES;
+  gameState.message = '';
+  updateHud();
+  prepareLevel();
+}
+
+function handleLifeLost() {
+  if (gameState.status !== 'running') {
+    return;
+  }
+
+  gameState.lives -= 1;
+  updateHud();
+
+  if (gameState.lives > 0) {
+    setStatus('ready', `残りライフ ${gameState.lives}！スペースキーまたはボタンで再開`);
+    resetPaddle();
+    placeBallAbovePaddle();
+  } else {
+    setStatus('gameOver', 'ゲームオーバー… スタートで再挑戦');
+    resetPaddle();
+    placeBallAbovePaddle();
+  }
+}
+
+function handleLevelClear() {
+  if (gameState.status !== 'running') {
+    return;
+  }
+
+  updateScore(150);
+  gameState.level += 1;
+  const gainedLife = (gameState.level - 1) % 3 === 0;
+
+  if (gainedLife) {
+    gameState.lives += 1;
+  }
+
+  updateHud();
+  prepareLevel({
+    message: gainedLife
+      ? `レベル${gameState.level} スタート準備完了！ライフが1つ増えました`
+      : undefined,
+  });
+}
+
+function updateBallSpeedAfterHit() {
+  const currentSpeed = Math.max(Math.hypot(ball.dx, ball.dy), 0.0001);
+  const target = Math.min(currentSpeed * 1.03, 7.5 + gameState.level * 0.6);
+  const scale = target / currentSpeed;
+  ball.dx *= scale;
+  ball.dy *= scale;
+  ball.speed = target;
+}
+
+function moveBall() {
+  ball.x += ball.dx;
+  ball.y += ball.dy;
+
+  if (ball.x + ball.radius > BASE_WIDTH || ball.x - ball.radius < 0) {
+    ball.dx = -ball.dx;
+    ball.x = clamp(ball.x, ball.radius, BASE_WIDTH - ball.radius);
+  }
+
+  if (ball.y - ball.radius < 0) {
+    ball.dy = -ball.dy;
+    ball.y = ball.radius;
+  }
+
+  const hitsPaddleVertically =
+    ball.y + ball.radius >= paddle.y && ball.y - ball.radius <= paddle.y + paddle.height;
+
+  if (hitsPaddleVertically && ball.x >= paddle.x && ball.x <= paddle.x + paddle.width) {
+    const hitPos = (ball.x - (paddle.x + paddle.width / 2)) / (paddle.width / 2);
+    const maxBounce = (5 * Math.PI) / 12;
+    const bounceAngle = hitPos * maxBounce;
+    const speed = Math.max(Math.hypot(ball.dx, ball.dy), ball.speed);
+    ball.dx = speed * Math.sin(bounceAngle);
+    ball.dy = -Math.abs(speed * Math.cos(bounceAngle));
+    ball.y = paddle.y - ball.radius - 1;
+  }
+
+  if (ball.y - ball.radius > BASE_HEIGHT) {
+    handleLifeLost();
+  }
+}
+
+function checkBrickCollisions() {
+  for (const brick of bricks) {
+    if (brick.status <= 0) {
+      continue;
+    }
+
+    const overlapsX = ball.x + ball.radius > brick.x && ball.x - ball.radius < brick.x + brick.width;
+    const overlapsY = ball.y + ball.radius > brick.y && ball.y - ball.radius < brick.y + brick.height;
+
+    if (!overlapsX || !overlapsY) {
+      continue;
+    }
+
+    brick.status -= 1;
+    updateScore(10 + (gameState.level - 1) * 2);
+
+    const overlapLeft = ball.x + ball.radius - brick.x;
+    const overlapRight = brick.x + brick.width - (ball.x - ball.radius);
+    const overlapTop = ball.y + ball.radius - brick.y;
+    const overlapBottom = brick.y + brick.height - (ball.y - ball.radius);
+    const minOverlap = Math.min(overlapLeft, overlapRight, overlapTop, overlapBottom);
+
+    if (minOverlap === overlapLeft || minOverlap === overlapRight) {
+      ball.dx = -ball.dx;
+    } else {
+      ball.dy = -ball.dy;
+    }
+
+    updateBallSpeedAfterHit();
+
+    if (!bricks.some((b) => b.status > 0)) {
+      handleLevelClear();
+    }
+
+    return;
+  }
+}
+
+function drawBackground() {
+  const gradient = ctx.createLinearGradient(0, 0, BASE_WIDTH, BASE_HEIGHT);
+  gradient.addColorStop(0, 'rgba(14, 165, 233, 0.18)');
+  gradient.addColorStop(1, 'rgba(30, 64, 175, 0.08)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, BASE_WIDTH, BASE_HEIGHT);
+}
+
+function drawPaddle() {
+  ctx.fillStyle = '#38bdf8';
+  roundedRectPath(paddle.x, paddle.y, paddle.width, paddle.height, 8);
+  ctx.fill();
+}
+
+function drawBall() {
+  const gradient = ctx.createRadialGradient(ball.x, ball.y, 2, ball.x, ball.y, ball.radius + 5);
+  gradient.addColorStop(0, '#f8fafc');
+  gradient.addColorStop(1, '#f97316');
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+function drawBricks() {
+  bricks.forEach((brick) => {
+    if (brick.status <= 0) {
+      return;
+    }
+
+    const brightness = 60 + brick.status * 6;
+    const gradient = ctx.createLinearGradient(brick.x, brick.y, brick.x, brick.y + brick.height);
+    gradient.addColorStop(0, `hsl(${brick.hue}, 85%, ${brightness + 12}%)`);
+    gradient.addColorStop(1, `hsl(${brick.hue + 16}, 70%, ${brightness}%)`);
+    ctx.fillStyle = gradient;
+    roundedRectPath(brick.x, brick.y, brick.width, brick.height, 6);
+    ctx.fill();
+  });
+}
+
+function wrapText(message, maxWidth) {
+  ctx.font = '18px "Segoe UI", sans-serif';
+  const lines = [];
+  let currentLine = '';
+
+  for (const char of message) {
+    const testLine = currentLine + char;
+    if (ctx.measureText(testLine).width > maxWidth && currentLine) {
+      lines.push(currentLine);
+      currentLine = char === ' ' ? '' : char;
+    } else {
+      currentLine = testLine;
+    }
+  }
+
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+
+  return lines;
+}
+
+function drawMessage() {
+  if (!gameState.message) {
+    return;
+  }
+
+  ctx.save();
+  const lines = wrapText(gameState.message, 260);
+  const lineHeight = 26;
+  const boxWidth = 320;
+  const boxHeight = lines.length * lineHeight + 28;
+  const boxX = BASE_WIDTH / 2 - boxWidth / 2;
+  const boxY = BASE_HEIGHT / 2 - boxHeight / 2;
+
+  ctx.fillStyle = 'rgba(15, 23, 42, 0.78)';
+  roundedRectPath(boxX, boxY, boxWidth, boxHeight, 16);
+  ctx.fill();
+
+  ctx.fillStyle = '#f8fafc';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = '18px "Segoe UI", sans-serif';
+
+  lines.forEach((line, index) => {
+    const textY = boxY + 14 + index * lineHeight + lineHeight / 2;
+    ctx.fillText(line, BASE_WIDTH / 2, textY);
+  });
+
+  ctx.restore();
+}
+
+function draw() {
+  ctx.clearRect(0, 0, BASE_WIDTH, BASE_HEIGHT);
+  drawBackground();
+  drawBricks();
+  drawPaddle();
+  drawBall();
+  drawMessage();
+}
+
+function updatePaddleFromInput() {
+  if (input.left && !input.right) {
+    paddle.x -= paddle.speed;
+  } else if (input.right && !input.left) {
+    paddle.x += paddle.speed;
+  }
+
+  paddle.x = clamp(paddle.x, 0, BASE_WIDTH - paddle.width);
+}
+
+function gameLoop() {
+  updatePaddleFromInput();
+
+  if (gameState.status === 'ready') {
+    placeBallAbovePaddle();
+  }
+
+  if (gameState.status === 'running') {
+    moveBall();
+    checkBrickCollisions();
+  }
+
+  draw();
+  gameState.animationId = requestAnimationFrame(gameLoop);
+}
+
+function handlePointer(clientX) {
+  const rect = canvas.getBoundingClientRect();
+  const scale = BASE_WIDTH / rect.width;
+  const position = (clientX - rect.left) * scale - paddle.width / 2;
+  paddle.x = clamp(position, 0, BASE_WIDTH - paddle.width);
+}
+
+canvas.addEventListener('mousemove', (event) => {
+  handlePointer(event.clientX);
+});
+
+canvas.addEventListener(
+  'touchstart',
+  (event) => {
+    if (event.touches.length > 0) {
+      handlePointer(event.touches[0].clientX);
+    }
+  },
+  { passive: true },
+);
+
+canvas.addEventListener(
+  'touchmove',
+  (event) => {
+    if (event.touches.length > 0) {
+      event.preventDefault();
+      handlePointer(event.touches[0].clientX);
+    }
+  },
+  { passive: false },
+);
+
+startButton.addEventListener('click', () => {
+  if (gameState.status === 'idle') {
+    startNewGame();
+    launchBall();
+    return;
+  }
+
+  if (gameState.status === 'gameOver') {
+    startNewGame();
+    launchBall();
+    return;
+  }
+
+  if (gameState.status === 'ready') {
+    launchBall();
+    return;
+  }
+
+  if (gameState.status === 'running') {
+    pauseGame();
+    return;
+  }
+
+  if (gameState.status === 'paused') {
+    resumeGame();
+  }
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'ArrowLeft' || event.key === 'a') {
+    input.left = true;
+    event.preventDefault();
+  } else if (event.key === 'ArrowRight' || event.key === 'd') {
+    input.right = true;
+    event.preventDefault();
+  } else if (event.key === ' ') {
+    event.preventDefault();
+    if (gameState.status === 'running') {
+      pauseGame();
+    } else if (gameState.status === 'paused') {
+      resumeGame();
+    } else if (gameState.status === 'ready') {
+      launchBall();
+    } else if (gameState.status === 'idle') {
+      startNewGame();
+      launchBall();
+    } else if (gameState.status === 'gameOver') {
+      startNewGame();
+      launchBall();
+    }
+  }
+});
+
+document.addEventListener('keyup', (event) => {
+  if (event.key === 'ArrowLeft' || event.key === 'a') {
+    input.left = false;
+    event.preventDefault();
+  } else if (event.key === 'ArrowRight' || event.key === 'd') {
+    input.right = false;
+    event.preventDefault();
+  }
+});
+
+window.addEventListener('resize', () => {
+  setupCanvas();
+  draw();
+});
+
+setupCanvas();
+prepareLevel({ announce: false });
+setStatus('idle', 'スタートボタンでゲーム開始！');
+updateHud();
+draw();
+requestAnimationFrame(gameLoop);

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,151 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0e1116;
+  --text: #f6f8fa;
+  --accent: #f97316;
+  --card: #161b22;
+  --border: rgba(255, 255, 255, 0.08);
+  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(160deg, #0f172a 0%, #1e293b 40%, #0f172a 100%);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1.5rem;
+}
+
+.game-wrapper {
+  width: min(100%, 900px);
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  box-shadow: 0 30px 80px rgba(2, 6, 23, 0.7);
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.game-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.game-header h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  letter-spacing: 0.05em;
+}
+
+.scoreboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 0.75rem;
+}
+
+.scoreboard__item {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.scoreboard__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(248, 250, 252, 0.75);
+}
+
+.scoreboard__value {
+  font-size: clamp(1.1rem, 3vw, 1.5rem);
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.game-area {
+  display: grid;
+  justify-items: center;
+  gap: 1rem;
+}
+
+canvas {
+  width: min(100%, 480px);
+  height: auto;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.05), rgba(8, 47, 73, 0.95));
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-radius: 1rem;
+  touch-action: none;
+}
+
+.controls button {
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.controls button:hover,
+.controls button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 30px rgba(249, 115, 22, 0.35);
+}
+
+.instructions {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  line-height: 1.7;
+}
+
+.instructions h2 {
+  margin-top: 0;
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.instructions ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.instructions li + li {
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1rem;
+  }
+
+  .game-wrapper {
+    border-radius: 1rem;
+  }
+
+  .game-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .controls button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive index page that loads the block breaker game assets with an expanded HUD for score, level, lives, and high score
- implement the canvas-based block breaker gameplay with level progression, lives, keyboard/touch controls, and pause/resume handling
- style the layout for desktop and touch devices with responsive controls and a scoreboard card layout

## How to Play
- click or tap the start button (or press space) to begin or resume a round
- move the paddle with the mouse, drag a finger on touch screens, or use the arrow/A-D keys
- clear every brick across increasingly challenging levels without losing all of your lives

## Testing
- not run (browser-based manual testing recommended)

------
https://chatgpt.com/codex/tasks/task_e_69094027f5dc83299a13b734456e496c