### PR TITLE
タイトル/リザルト画面の非同期遷移をゲーム進行に連動

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="src/style.css" />
   </head>
   <body>
+    <div id="screen-root" class="screen-root" aria-live="polite"></div>
     <main class="game-wrapper">
       <header class="game-header">
         <h1>ブロック崩し</h1>

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,5 @@
+import { hideScreen, showResultScreen, showTitleScreen } from './screenNavigation.js';
+
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 const startButton = document.getElementById('startButton');
@@ -273,6 +275,7 @@ function handleLifeLost() {
     setStatus('gameOver', 'ゲームオーバー… スタートで再挑戦');
     resetPaddle();
     placeBallAbovePaddle();
+    presentResultScreen();
   }
 }
 
@@ -295,6 +298,33 @@ function handleLevelClear() {
     message: gainedLife
       ? `レベル${gameState.level} スタート準備完了！ライフが1つ増えました`
       : undefined,
+  });
+}
+
+function startGameFromTitle() {
+  hideScreen();
+  startNewGame();
+  launchBall();
+}
+
+function showTitleAfterReset() {
+  gameState.score = 0;
+  gameState.level = 1;
+  gameState.lives = INITIAL_LIVES;
+  prepareLevel({ announce: false });
+  setStatus('idle', 'スタートボタンでゲーム開始！');
+  updateHud();
+  draw();
+  showTitleScreen({ onStart: startGameFromTitle });
+}
+
+function presentResultScreen() {
+  showResultScreen({
+    score: gameState.score,
+    highScore: gameState.highScore,
+    onBackToTitle: () => {
+      showTitleAfterReset();
+    },
   });
 }
 
@@ -611,12 +641,14 @@ canvas.addEventListener(
 
 startButton.addEventListener('click', () => {
   if (gameState.status === 'idle') {
+    hideScreen();
     startNewGame();
     launchBall();
     return;
   }
 
   if (gameState.status === 'gameOver') {
+    hideScreen();
     startNewGame();
     launchBall();
     return;
@@ -653,9 +685,11 @@ document.addEventListener('keydown', (event) => {
     } else if (gameState.status === 'ready') {
       launchBall();
     } else if (gameState.status === 'idle') {
+      hideScreen();
       startNewGame();
       launchBall();
     } else if (gameState.status === 'gameOver') {
+      hideScreen();
       startNewGame();
       launchBall();
     }
@@ -678,8 +712,5 @@ window.addEventListener('resize', () => {
 });
 
 setupCanvas();
-prepareLevel({ announce: false });
-setStatus('idle', 'スタートボタンでゲーム開始！');
-updateHud();
-draw();
+showTitleAfterReset();
 requestAnimationFrame(gameLoop);

--- a/src/screenNavigation.js
+++ b/src/screenNavigation.js
@@ -1,0 +1,100 @@
+const screenRoot = document.getElementById('screen-root');
+
+let activeTransitionId = 0;
+let cleanupCurrentScreen = null;
+
+function clearCurrentScreen() {
+  if (cleanupCurrentScreen) {
+    try {
+      cleanupCurrentScreen();
+    } finally {
+      cleanupCurrentScreen = null;
+    }
+  }
+  if (screenRoot) {
+    screenRoot.innerHTML = '';
+  }
+}
+
+function renderLoadingMessage() {
+  if (!screenRoot) {
+    return;
+  }
+  clearCurrentScreen();
+  const loading = document.createElement('div');
+  loading.className = 'screen screen--loading';
+  loading.innerHTML = '<p class="screen__message">読み込み中...</p>';
+  screenRoot.appendChild(loading);
+}
+
+function renderErrorMessage() {
+  if (!screenRoot) {
+    return;
+  }
+  clearCurrentScreen();
+  const wrapper = document.createElement('div');
+  wrapper.className = 'screen';
+
+  const message = document.createElement('p');
+  message.className = 'screen__message';
+  message.textContent = '画面の読み込みに失敗しました。ページを再読み込みしてください。';
+
+  wrapper.appendChild(message);
+  screenRoot.appendChild(wrapper);
+}
+
+function renderScreen(screen) {
+  if (!screenRoot) {
+    return;
+  }
+  clearCurrentScreen();
+  screenRoot.appendChild(screen.element);
+  cleanupCurrentScreen = screen.cleanup ?? null;
+}
+
+async function transitionTo(loadScreen) {
+  activeTransitionId += 1;
+  const transitionId = activeTransitionId;
+
+  renderLoadingMessage();
+
+  try {
+    const screen = await loadScreen();
+    if (transitionId !== activeTransitionId) {
+      if (typeof screen.cleanup === 'function') {
+        screen.cleanup();
+      }
+      return;
+    }
+    renderScreen(screen);
+  } catch (error) {
+    console.error('Failed to load screen', error);
+    if (transitionId !== activeTransitionId) {
+      return;
+    }
+    renderErrorMessage();
+  }
+}
+
+function hideScreen() {
+  activeTransitionId += 1;
+  clearCurrentScreen();
+}
+
+async function showTitleScreen(options = {}) {
+  const { onStart } = options;
+  await transitionTo(async () => {
+    const module = await import('./screens/titleScreen.js');
+    return module.createTitleScreen({ onStart });
+  });
+}
+
+async function showResultScreen(options = {}) {
+  const { score, highScore, onBackToTitle } = options;
+  await transitionTo(async () => {
+    const module = await import('./screens/resultScreen.js');
+    return module.createResultScreen({ score, highScore, onBackToTitle });
+  });
+}
+
+export { hideScreen, showResultScreen, showTitleScreen };

--- a/src/screens/resultScreen.js
+++ b/src/screens/resultScreen.js
@@ -1,0 +1,37 @@
+function createResultScreen({ score = 0, highScore = 0, onBackToTitle } = {}) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'screen';
+
+  const heading = document.createElement('h2');
+  heading.className = 'screen__title';
+  heading.textContent = 'ゲーム結果';
+
+  const description = document.createElement('p');
+  description.className = 'screen__message';
+  description.innerHTML = `今回のスコア: <strong>${score}</strong><br />ハイスコア: <strong>${highScore}</strong>`;
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'screen__button';
+  button.textContent = 'タイトルへ戻る';
+  if (typeof onBackToTitle === 'function') {
+    button.addEventListener('click', onBackToTitle);
+  } else {
+    button.disabled = true;
+  }
+
+  wrapper.appendChild(heading);
+  wrapper.appendChild(description);
+  wrapper.appendChild(button);
+
+  return {
+    element: wrapper,
+    cleanup: () => {
+      if (typeof onBackToTitle === 'function') {
+        button.removeEventListener('click', onBackToTitle);
+      }
+    },
+  };
+}
+
+export { createResultScreen };

--- a/src/screens/titleScreen.js
+++ b/src/screens/titleScreen.js
@@ -1,0 +1,37 @@
+function createTitleScreen({ onStart } = {}) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'screen';
+
+  const heading = document.createElement('h2');
+  heading.className = 'screen__title';
+  heading.textContent = 'ブロック崩し';
+
+  const description = document.createElement('p');
+  description.className = 'screen__message';
+  description.textContent = '「ゲーム開始」を押すとプレイが始まります。';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'screen__button';
+  button.textContent = 'ゲーム開始';
+  if (typeof onStart === 'function') {
+    button.addEventListener('click', onStart);
+  } else {
+    button.disabled = true;
+  }
+
+  wrapper.appendChild(heading);
+  wrapper.appendChild(description);
+  wrapper.appendChild(button);
+
+  return {
+    element: wrapper,
+    cleanup: () => {
+      if (typeof onStart === 'function') {
+        button.removeEventListener('click', onStart);
+      }
+    },
+  };
+}
+
+export { createTitleScreen };

--- a/src/style.css
+++ b/src/style.css
@@ -149,3 +149,78 @@ canvas {
     width: 100%;
   }
 }
+
+.screen-root {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.72);
+  z-index: 1000;
+}
+
+.screen-root:empty {
+  display: none;
+}
+
+.screen {
+  width: min(320px, 100%);
+  background: #ffffff;
+  color: #0f172a;
+  border-radius: 12px;
+  padding: 1.75rem 1.5rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+}
+
+.screen__title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.screen__message {
+  margin: 0;
+  line-height: 1.6;
+  color: #1f2937;
+}
+
+.screen__button {
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.screen__button:hover,
+.screen__button:focus-visible {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.screen__button:disabled {
+  background: #93c5fd;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.screen--loading {
+  background: transparent;
+  color: #f8fafc;
+  box-shadow: none;
+  gap: 0;
+}
+
+.screen--loading .screen__message {
+  color: #f8fafc;
+  font-weight: 600;
+}


### PR DESCRIPTION
## 概要
- タイトル/リザルト画面の読み込みを共通ナビゲーションで扱い、ゲーム開始・終了イベントと連動
- タイトル画面からゲーム開始、ゲームオーバー時に結果画面を表示するよう `app.js` を更新
- プレースホルダー画面用のスタイルをシンプルな文字＋ボタン構成に調整

## スクリーンショット
| タイトル画面 | リザルト画面 |
|---------------|---------------|
| ![タイトル画面](https://github.com/user-attachments/assets/5626db3c-ddcd-4f65-be74-aba3e1aed9d9) | ![リザルト画面](https://github.com/user-attachments/assets/f1f9e88e-cb03-4853-a2f3-fe0a0a9a1717) |


## テスト
- 手動確認（`python -m http.server 8000` で起動し、タイトル表示とゲーム開始・リザルト遷移を確認）

------
https://chatgpt.com/codex/tasks/task_e_6909d9f8f9ac83298b9fa1b4bb222e67